### PR TITLE
ci: Remove auto-approve PR steps

### DIFF
--- a/.github/workflows/dependabot-automation.yml
+++ b/.github/workflows/dependabot-automation.yml
@@ -17,26 +17,6 @@ defaults:
     shell: bash
 
 jobs:
-  auto-approve:
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Dependabot metadata
-        id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1
-      - uses: actions/checkout@v4
-      - name: Approve a PR if not already approved
-        run: |
-          gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
-          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ]; then
-            gh pr review --approve "$PR_URL"
-          else
-            echo "PR already approved, skipping additional approvals to minimize emails/notification noise."
-          fi
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-
   enable-automerge:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]'}}
     runs-on: ubuntu-22.04

--- a/.github/workflows/devbox-update.yml
+++ b/.github/workflows/devbox-update.yml
@@ -73,7 +73,6 @@ jobs:
 
       - name: Create PR using app token
         if: steps.devbox-versions-changed.outputs.number_changed > 0
-        id: create-pr
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
@@ -82,15 +81,3 @@ jobs:
             --body "This PR was automatically created by the scheduled devbox update workflow." \
             --label ignore-for-release)"
           gh pr merge --auto --squash "${pr_url}"
-          echo "pr_url=${pr_url}" >>"${GITHUB_OUTPUT}"
-
-      - name: Approve PR using workflow token
-        if: steps.devbox-versions-changed.outputs.number_changed > 0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ]; then
-            gh pr review --approve "${{ steps.create-pr.outputs.pr_url }}"
-          else
-            echo "PR already approved, skipping additional approvals to minimize emails/notification noise."
-          fi


### PR DESCRIPTION
This is disallowed by GH org settings.