### PR TITLE
test: Ensure defaults from JSON schema are respected

### DIFF
--- a/common/go.mod
+++ b/common/go.mod
@@ -63,6 +63,7 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.14.0 // indirect
+	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/common/pkg/testutils/openapi/convert.go
+++ b/common/pkg/testutils/openapi/convert.go
@@ -14,7 +14,7 @@ import (
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
-// convertToAPIExtensionsJSONSchemaProps converts a clusterv1.JSONSchemaProps to apiextensions.JSONSchemaProp.
+// ConvertToAPIExtensionsJSONSchemaProps converts a clusterv1.JSONSchemaProps to apiextensions.JSONSchemaProp.
 // NOTE: This is used whenever we want to use one of the upstream libraries, as they use apiextensions.JSONSchemaProp.
 // NOTE: If new fields are added to clusterv1.JSONSchemaProps (e.g. to support complex types), the corresponding
 // schema validation must be added to validateRootSchema too.

--- a/common/pkg/testutils/openapi/validate.go
+++ b/common/pkg/testutils/openapi/validate.go
@@ -10,6 +10,7 @@ import (
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	structuralschema "k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting"
 	structuralpruning "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning"
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -61,6 +62,18 @@ func ValidateClusterVariable(
 			),
 		)}
 	}
+
+	s, err := structuralschema.NewStructural(apiExtensionsSchema)
+	if err != nil {
+		return field.ErrorList{field.InternalError(fldPath,
+			fmt.Errorf(
+				"failed to create structural schema for variable %q; ClusterClass should be checked: %v",
+				value.Name,
+				err,
+			),
+		)}
+	}
+	defaulting.Default(variableValue, s)
 
 	// Validate variable against the schema.
 	// NOTE: We're reusing a library func used in CRD validation.


### PR DESCRIPTION
Without this, defaults declared in the JSON schema are not included in validation
steps, which can lead to invalid failures, while also not allowing for tests that
target defaults.
