### PR TITLE
build: add Nutanix infra provider

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/templates/clusterclass_nutanix.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/templates/clusterclass_nutanix.yaml
@@ -1,0 +1,6 @@
+# Copyright 2023 D2iQ, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.deployDefaultClusterClasses (.Capabilities.APIVersions.Has "infrastructure.cluster.x-k8s.io/v1beta1/NutanixClusterTemplate") }}
+{{ .Files.Get "defaultclusterclasses/nutanix-cluster-class.yaml" }}
+{{- end}}

--- a/make/clusterctl.mk
+++ b/make/clusterctl.mk
@@ -1,6 +1,10 @@
 # Copyright 2023 D2iQ, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+export CAPA_VERSION := $(shell cd hack/third-party/capa && go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-provider-aws/v2)
+export CAPX_VERSION := $(shell cd hack/third-party/capx && go list -m -f '{{ .Version }}' github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
+
+# Leave Nutanix credentials empty here and set it when creating the clusters
 .PHONY: clusterctl.init
 clusterctl.init:
 	env CLUSTER_TOPOLOGY=true \
@@ -8,9 +12,10 @@ clusterctl.init:
 	    EXP_CLUSTER_RESOURCE_SET=true \
 	    EXP_MACHINE_POOL=true \
 	    AWS_B64ENCODED_CREDENTIALS=$$(clusterawsadm bootstrap credentials encode-as-profile) \
+	    NUTANIX_ENDPOINT="" NUTANIX_PASSWORD="" NUTANIX_USER="" \
 	    clusterctl init \
 	      --kubeconfig=$(KIND_KUBECONFIG) \
-	      --infrastructure docker,aws \
+	      --infrastructure docker,aws:${CAPA_VERSION},nutanix:${CAPX_VERSION} \
 	      --addon helm \
 	      --wait-providers
 


### PR DESCRIPTION
Deploy CAPX and the default clusterclass and templates. This will unblock all of us working on CAPX related work.

I also added the versions to deploy in `make/clusterctl.mk` to match the synced API version, otherwise `clusterctl` will fetch the latest stable version (in the case of CAPX) or a newer provider version that doesn't match the API.