### PR TITLE
fix:  new configmap for tigera resources

### DIFF
--- a/pkg/handlers/generic/lifecycle/cni/calico/strategy_crs.go
+++ b/pkg/handlers/generic/lifecycle/cni/calico/strategy_crs.go
@@ -204,7 +204,7 @@ func generateTigeraOperatorConfigMap(
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: cluster.Namespace,
-			Name:      defaultTigeraOperatorConfigMap.Name,
+			Name:      fmt.Sprintf("%s-%s", defaultTigeraOperatorConfigMap.Name, cluster.Name),
 		},
 		Data:       defaultTigeraOperatorConfigMap.Data,
 		BinaryData: defaultTigeraOperatorConfigMap.BinaryData,


### PR DESCRIPTION
Fixes a bug that incorrectly used the name of the template rather than creating a new resource from the template for that cluster.