### PR TITLE
test: Fix data race

### DIFF
--- a/make/go.mk
+++ b/make/go.mk
@@ -26,6 +26,7 @@ define go_test
 		-covermode=atomic \
 		-coverprofile=coverage.out \
 		-short \
+		-race \
 		-v \
 		$(if $(GOTEST_RUN),-run "$(GOTEST_RUN)") \
 		./... && \

--- a/pkg/handlers/aws/mutation/suite_test.go
+++ b/pkg/handlers/aws/mutation/suite_test.go
@@ -4,6 +4,7 @@
 package mutation
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -18,12 +19,13 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	setup()
-	defer teardown()
+	setupCtx, cancel := context.WithCancel(ctx)
+	setup(setupCtx)
+	defer teardown(cancel)
 	m.Run()
 }
 
-func setup() {
+func setup(ctx context.Context) {
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration()
 	var err error
 	testEnv, err = testEnvConfig.Build()
@@ -38,7 +40,8 @@ func setup() {
 	}()
 }
 
-func teardown() {
+func teardown(cancel context.CancelFunc) {
+	cancel()
 	if err := testEnv.Stop(); err != nil {
 		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
 	}

--- a/pkg/handlers/docker/mutation/suite_test.go
+++ b/pkg/handlers/docker/mutation/suite_test.go
@@ -4,6 +4,7 @@
 package mutation
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -18,12 +19,13 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	setup()
-	defer teardown()
+	setupCtx, cancel := context.WithCancel(ctx)
+	setup(setupCtx)
+	defer teardown(cancel)
 	m.Run()
 }
 
-func setup() {
+func setup(ctx context.Context) {
 	testEnvConfig := helpers.NewTestEnvironmentConfiguration()
 	var err error
 	testEnv, err = testEnvConfig.Build()
@@ -38,7 +40,8 @@ func setup() {
 	}()
 }
 
-func teardown() {
+func teardown(cancel context.CancelFunc) {
+	cancel()
 	if err := testEnv.Stop(); err != nil {
 		panic(fmt.Sprintf("Failed to stop envtest: %v", err))
 	}

--- a/test/helpers/envtest.go
+++ b/test/helpers/envtest.go
@@ -132,14 +132,11 @@ func (t *TestEnvironmentConfiguration) Build() (*TestEnvironment, error) {
 
 // StartManager starts the test controller against the local API server.
 func (t *TestEnvironment) StartManager(ctx context.Context) error {
-	ctx, cancel := context.WithCancel(ctx)
-	t.cancel = cancel
 	return t.Manager.Start(ctx)
 }
 
 // Stop stops the test environment.
 func (t *TestEnvironment) Stop() error {
-	t.cancel()
 	return t.env.Stop()
 }
 


### PR DESCRIPTION
This fixes a data race due to a stored context that may not yet be initialized when `teardown` is called.

To reproduce, see https://github.com/dlipovetsky/capi-runtime-extensions/commit/bf999ae04ccf802ee5c30756d38a15dd9a921b21.