### PR TITLE
test: Fix false negative in auditpolicy test

### DIFF
--- a/pkg/handlers/generic/mutation/auditpolicy/tests/generate_patches.go
+++ b/pkg/handlers/generic/mutation/auditpolicy/tests/generate_patches.go
@@ -25,12 +25,16 @@ func TestGeneratePatches(
 			Name: "unset variable",
 		},
 		capitest.PatchTestDef{
-			Name:        "http proxy set for KubeadmControlPlaneTemplate",
+			Name:        "auditpolicy set for KubeadmControlPlaneTemplate",
 			RequestItem: request.NewKubeadmControlPlaneTemplateRequestItem(""),
 			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
-				Operation:    "add",
-				Path:         "/spec/template/spec/kubeadmConfigSpec/files",
-				ValueMatcher: gomega.HaveLen(1),
+				Operation: "add",
+				Path:      "/spec/template/spec/kubeadmConfigSpec/files",
+				ValueMatcher: gomega.ContainElements(
+					gomega.HaveKeyWithValue(
+						"path", "/etc/kubernetes/audit-policy/apiserver-audit-policy.yaml",
+					),
+				),
 			}, {
 				Operation: "add",
 				Path:      "/spec/template/spec/kubeadmConfigSpec/clusterConfiguration",


### PR DESCRIPTION
Other patches can change the slice length, causing the previous check to fail, although all correct patches are present.