### PR TITLE
test: Fix false negative in httpproxy test

### DIFF
--- a/pkg/handlers/generic/mutation/httpproxy/tests/generate_patches.go
+++ b/pkg/handlers/generic/mutation/httpproxy/tests/generate_patches.go
@@ -53,9 +53,16 @@ func TestGeneratePatches(
 			},
 			RequestItem: request.NewKubeadmConfigTemplateRequestItem(""),
 			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
-				Operation:    "add",
-				Path:         "/spec/template/spec/files",
-				ValueMatcher: gomega.HaveLen(2),
+				Operation: "add",
+				Path:      "/spec/template/spec/files",
+				ValueMatcher: gomega.ContainElements(
+					gomega.HaveKeyWithValue(
+						"path", "/etc/systemd/system/containerd.service.d/http-proxy.conf",
+					),
+					gomega.HaveKeyWithValue(
+						"path", "/etc/systemd/system/kubelet.service.d/http-proxy.conf",
+					),
+				),
 			}},
 		},
 		capitest.PatchTestDef{


### PR DESCRIPTION
Other patches can change the slice length, causing the previous check to fail, although all correct patches are present.