### PR TITLE
fix: Nutanix examples

### DIFF
--- a/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
+++ b/charts/cluster-api-runtime-extensions-nutanix/defaultclusterclasses/nutanix-cluster-class.yaml
@@ -154,9 +154,9 @@ spec:
                     - name: vip_arp
                       value: "true"
                     - name: address
-                      value: "${CONTROL_PLANE_ENDPOINT_IP}"
+                      value: "control_plane_endpoint_ip"
                     - name: port
-                      value: "${CONTROL_PLANE_ENDPOINT_PORT=6443}"
+                      value: "control_plane_endpoint_port"
                     - name: vip_cidr
                       value: "32"
                     - name: cp_enable

--- a/hack/examples/bases/nutanix/cluster/kustomization.yaml.tmpl
+++ b/hack/examples/bases/nutanix/cluster/kustomization.yaml.tmpl
@@ -5,7 +5,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://raw.githubusercontent.com/nutanix-cloud-native/cluster-api-provider-nutanix/main/templates/cluster-template-topology.yaml
+- https://raw.githubusercontent.com/nutanix-cloud-native/cluster-api-provider-nutanix/51aa55fe8b194a261bc3cc4e6d24f5d430ec055a/templates/cluster-template-topology.yaml
 
 sortOptions:
   order: fifo

--- a/hack/examples/bases/nutanix/clusterclass/kustomization.yaml.tmpl
+++ b/hack/examples/bases/nutanix/clusterclass/kustomization.yaml.tmpl
@@ -5,7 +5,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://raw.githubusercontent.com/nutanix-cloud-native/cluster-api-provider-nutanix/main/templates/cluster-template-clusterclass.yaml
+- https://raw.githubusercontent.com/nutanix-cloud-native/cluster-api-provider-nutanix/51aa55fe8b194a261bc3cc4e6d24f5d430ec055a/templates/cluster-template-clusterclass.yaml
 
 configurations:
   - kustomizeconfig.yaml


### PR DESCRIPTION
A change was merged upstream and because this repo was just using `main` it broke the pre-commit check for all PRs.
Fixing the example and pinning the sync script to a commit so that it doesn't happen in the future.
We'll have a proper release that can he used in the future.