### PR TITLE
test: move all AWS patch unit tests to their own packages

### DIFF
--- a/pkg/handlers/aws/mutation/ami/inject_control_plane_test.go
+++ b/pkg/handlers/aws/mutation/ami/inject_control_plane_test.go
@@ -1,0 +1,100 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ami
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+)
+
+var _ = Describe("Generate AMI patches for ControlPlane", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+	}
+
+	testDefs := []capitest.PatchTestDef{
+		{
+			Name: "AMI set for control plane",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					clusterconfig.MetaVariableName,
+					v1alpha1.AMISpec{ID: "ami-controlplane"},
+					clusterconfig.MetaControlPlaneConfigName,
+					v1alpha1.AWSVariableName,
+					VariableName,
+				),
+			},
+			RequestItem: request.NewCPAWSMachineTemplateRequestItem("1234"),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation:    "add",
+					Path:         "/spec/template/spec/ami/id",
+					ValueMatcher: gomega.Equal("ami-controlplane"),
+				},
+			},
+		},
+		{
+			Name: "AMI lookup format set for control plane",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					clusterconfig.MetaVariableName,
+					v1alpha1.AMISpec{
+						Lookup: &v1alpha1.AMILookup{
+							Format: "test-{{.kubernetesVersion}}-format",
+							Org:    "1234",
+							BaseOS: "testOS",
+						},
+					},
+					clusterconfig.MetaControlPlaneConfigName,
+					v1alpha1.AWSVariableName,
+					VariableName,
+				),
+			},
+			RequestItem: request.NewCPAWSMachineTemplateRequestItem("1234"),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation:    "add",
+					Path:         "/spec/template/spec/imageLookupFormat",
+					ValueMatcher: gomega.Equal("test-{{.kubernetesVersion}}-format"),
+				},
+				{
+					Operation:    "add",
+					Path:         "/spec/template/spec/imageLookupOrg",
+					ValueMatcher: gomega.Equal("1234"),
+				},
+				{
+					Operation:    "add",
+					Path:         "/spec/template/spec/imageLookupBaseOS",
+					ValueMatcher: gomega.Equal("testOS"),
+				},
+			},
+			UnexpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation:    "add",
+					Path:         "/spec/template/spec/ami/id",
+					ValueMatcher: gomega.Equal(""),
+				},
+			},
+		},
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})

--- a/pkg/handlers/aws/mutation/ami/inject_suite_test.go
+++ b/pkg/handlers/aws/mutation/ami/inject_suite_test.go
@@ -1,0 +1,13 @@
+package ami
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAMIPatch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AMI patches for ControlPlane and Workers suite")
+}

--- a/pkg/handlers/aws/mutation/ami/inject_suite_test.go
+++ b/pkg/handlers/aws/mutation/ami/inject_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package ami
 
 import (

--- a/pkg/handlers/aws/mutation/ami/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/ami/inject_worker_test.go
@@ -1,12 +1,12 @@
 // Copyright 2023 D2iQ, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package tests
+package ami
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
@@ -14,99 +14,23 @@ import (
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
 )
 
-func TestControlPlaneGeneratePatches(
-	t *testing.T,
-	generatorFunc func() mutation.GeneratePatches,
-	variableName string,
-	variablePath ...string,
-) {
-	t.Helper()
+var _ = Describe("Generate AMI patches for Worker", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+	}
 
-	capitest.ValidateGeneratePatches(
-		t,
-		generatorFunc,
-		capitest.PatchTestDef{
-			Name: "AMI set for control plane",
-			Vars: []runtimehooksv1.Variable{
-				capitest.VariableWithValue(
-					variableName,
-					v1alpha1.AMISpec{ID: "ami-controlplane"},
-					variablePath...,
-				),
-			},
-			RequestItem: request.NewCPAWSMachineTemplateRequestItem("1234"),
-			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
-				{
-					Operation:    "add",
-					Path:         "/spec/template/spec/ami/id",
-					ValueMatcher: gomega.Equal("ami-controlplane"),
-				},
-			},
-		},
-		capitest.PatchTestDef{
-			Name: "AMI lookup format set for control plane",
-			Vars: []runtimehooksv1.Variable{
-				capitest.VariableWithValue(
-					variableName,
-					v1alpha1.AMISpec{
-						Lookup: &v1alpha1.AMILookup{
-							Format: "test-{{.kubernetesVersion}}-format",
-							Org:    "12345",
-							BaseOS: "testOS",
-						},
-					},
-					variablePath...,
-				),
-			},
-			RequestItem: request.NewCPAWSMachineTemplateRequestItem("1234"),
-			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
-				{
-					Operation:    "add",
-					Path:         "/spec/template/spec/imageLookupFormat",
-					ValueMatcher: gomega.Equal("test-{{.kubernetesVersion}}-format"),
-				},
-				{
-					Operation:    "add",
-					Path:         "/spec/template/spec/imageLookupOrg",
-					ValueMatcher: gomega.Equal("12345"),
-				},
-				{
-					Operation:    "add",
-					Path:         "/spec/template/spec/imageLookupBaseOS",
-					ValueMatcher: gomega.Equal("testOS"),
-				},
-			},
-			UnexpectedPatchMatchers: []capitest.JSONPatchMatcher{
-				{
-					Operation:    "add",
-					Path:         "/spec/template/spec/ami/id",
-					ValueMatcher: gomega.Equal(""),
-				},
-			},
-		},
-	)
-}
-
-func TestWorkerGeneratePatches(
-	t *testing.T,
-	generatorFunc func() mutation.GeneratePatches,
-	variableName string,
-	variablePath ...string,
-) {
-	t.Helper()
-
-	capitest.ValidateGeneratePatches(
-		t,
-		generatorFunc,
-		capitest.PatchTestDef{
+	testDefs := []capitest.PatchTestDef{
+		{
 			Name: "AMI set for workers",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
+					workerconfig.MetaVariableName,
 					v1alpha1.AMISpec{ID: "ami-controlplane"},
-					variablePath...,
+					v1alpha1.AWSVariableName,
+					VariableName,
 				),
 				capitest.VariableWithValue(
 					"builtin",
@@ -124,11 +48,11 @@ func TestWorkerGeneratePatches(
 				},
 			},
 		},
-		capitest.PatchTestDef{
+		{
 			Name: "AMI lookup format set for worker",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
+					workerconfig.MetaVariableName,
 					v1alpha1.AMISpec{
 						Lookup: &v1alpha1.AMILookup{
 							Format: "test-{{.kubernetesVersion}}-format",
@@ -136,8 +60,8 @@ func TestWorkerGeneratePatches(
 							BaseOS: "testOS",
 						},
 					},
-
-					variablePath...,
+					v1alpha1.AWSVariableName,
+					VariableName,
 				),
 				capitest.VariableWithValue(
 					"builtin",
@@ -172,5 +96,17 @@ func TestWorkerGeneratePatches(
 				},
 			},
 		},
-	)
-}
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})

--- a/pkg/handlers/aws/mutation/ami/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/ami/inject_worker_test.go
@@ -6,7 +6,6 @@ package ami
 import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 

--- a/pkg/handlers/aws/mutation/cni/calico/inject_test.go
+++ b/pkg/handlers/aws/mutation/cni/calico/inject_test.go
@@ -1,48 +1,48 @@
 // Copyright 2023 D2iQ, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package tests
+package calico
 
 import (
 	"testing"
 
+	capav1 "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	"github.com/onsi/gomega/format"
+
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
-	capav1 "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
 )
 
-func TestGeneratePatches(
-	t *testing.T,
-	generatorFunc func() mutation.GeneratePatches,
-	variableName string,
-	variablePath ...string,
-) {
-	t.Helper()
+func TestCalicoPatch(t *testing.T) {
+	gomega.RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS Calico CNI ingress mutator suite")
+}
 
-	format.MaxLength = 0
-	format.TruncatedDiff = false
+var _ = Describe("Generate AWS Calico CNI ingress patches", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+	}
 
-	capitest.ValidateGeneratePatches(
-		t,
-		generatorFunc,
-		capitest.PatchTestDef{
+	testDefs := []capitest.PatchTestDef{
+		{
 			Name: "unset variable",
 		},
-		capitest.PatchTestDef{
+		{
 			Name: "provider set with AWSClusterTemplate",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
+					clusterconfig.MetaVariableName,
 					v1alpha1.CNI{
 						Provider: v1alpha1.CNIProviderCalico,
 					},
-					variablePath...,
+					"addons",
+					v1alpha1.CNIVariableName,
 				),
 			},
 			RequestItem: request.NewAWSClusterTemplateRequestItem("1234"),
@@ -101,15 +101,16 @@ func TestGeneratePatches(
 				),
 			}},
 		},
-		capitest.PatchTestDef{
+		{
 			Name: "provider set with AWSClusterTemplate pre-existing rules",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
+					clusterconfig.MetaVariableName,
 					v1alpha1.CNI{
 						Provider: v1alpha1.CNIProviderCalico,
 					},
-					variablePath...,
+					"addons",
+					v1alpha1.CNIVariableName,
 				),
 			},
 			RequestItem: request.NewAWSClusterTemplateRequestItem(
@@ -193,15 +194,16 @@ func TestGeneratePatches(
 				),
 			}},
 		},
-		capitest.PatchTestDef{
+		{
 			Name: "provider set with AWSClusterTemplate conflicting pre-existing rules",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
+					clusterconfig.MetaVariableName,
 					v1alpha1.CNI{
 						Provider: v1alpha1.CNIProviderCalico,
 					},
-					variablePath...,
+					"addons",
+					v1alpha1.CNIVariableName,
 				),
 			},
 			RequestItem: request.NewAWSClusterTemplateRequestItem(
@@ -273,5 +275,17 @@ func TestGeneratePatches(
 				),
 			}},
 		},
-	)
-}
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})

--- a/pkg/handlers/aws/mutation/cni/calico/inject_test.go
+++ b/pkg/handlers/aws/mutation/cni/calico/inject_test.go
@@ -6,12 +6,11 @@ package calico
 import (
 	"testing"
 
-	capav1 "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
+	capav1 "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"

--- a/pkg/handlers/aws/mutation/controlplaneloadbalancer/inject_test.go
+++ b/pkg/handlers/aws/mutation/controlplaneloadbalancer/inject_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	. "github.com/onsi/gomega"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
 	capav1 "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/external/sigs.k8s.io/cluster-api-provider-aws/v2/api/v1beta2"
@@ -20,7 +19,7 @@ import (
 )
 
 func TestControlPlaneLoadBalancerPatch(t *testing.T) {
-	RegisterFailHandler(Fail)
+	gomega.RegisterFailHandler(Fail)
 	RunSpecs(t, "AWS ControlPlane LoadBalancer mutator suite")
 }
 

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_control_plane_test.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_control_plane_test.go
@@ -1,0 +1,58 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package iaminstanceprofile
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+)
+
+var _ = Describe("Generate IAMInstanceProfile patches for ControlPlane", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+	}
+
+	testDefs := []capitest.PatchTestDef{
+		{
+			Name: "unset variable",
+		},
+		{
+			Name: "iamInstanceProfile for control plane set",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					clusterconfig.MetaVariableName,
+					"control-plane.cluster-api-provider-aws.sigs.k8s.io",
+					clusterconfig.MetaControlPlaneConfigName,
+					v1alpha1.AWSVariableName,
+					VariableName,
+				),
+			},
+			RequestItem: request.NewCPAWSMachineTemplateRequestItem("1234"),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
+				Operation:    "add",
+				Path:         "/spec/template/spec/iamInstanceProfile",
+				ValueMatcher: gomega.Equal("control-plane.cluster-api-provider-aws.sigs.k8s.io"),
+			}},
+		},
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_suite_test.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_suite_test.go
@@ -1,0 +1,13 @@
+package iaminstanceprofile
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestIAMInstnaceProfilePatch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "IAMInstanceProfile patches for ControlPlane and Workers suite")
+}

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_suite_test.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package iaminstanceprofile
 
 import (

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker_test.go
@@ -1,74 +1,39 @@
 // Copyright 2023 D2iQ, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package tests
+package iaminstanceprofile
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
 )
 
-func TestControlPlaneGeneratePatches(
-	t *testing.T,
-	generatorFunc func() mutation.GeneratePatches,
-	variableName string,
-	variablePath ...string,
-) {
-	t.Helper()
+var _ = Describe("Generate IAMInstanceProfile patches for Worker", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+	}
 
-	capitest.ValidateGeneratePatches(
-		t,
-		generatorFunc,
-		capitest.PatchTestDef{
+	testDefs := []capitest.PatchTestDef{
+		{
 			Name: "unset variable",
 		},
-		capitest.PatchTestDef{
-			Name: "iamInstanceProfile set",
+		{
+			Name: "iamInstanceProfile for worker set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
-					"control-plane.cluster-api-provider-aws.sigs.k8s.io",
-					variablePath...,
-				),
-			},
-			RequestItem: request.NewCPAWSMachineTemplateRequestItem("1234"),
-			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
-				Operation:    "add",
-				Path:         "/spec/template/spec/iamInstanceProfile",
-				ValueMatcher: gomega.Equal("control-plane.cluster-api-provider-aws.sigs.k8s.io"),
-			}},
-		},
-	)
-}
-
-func TestWorkerGeneratePatches(
-	t *testing.T,
-	generatorFunc func() mutation.GeneratePatches,
-	variableName string,
-	variablePath ...string,
-) {
-	t.Helper()
-
-	capitest.ValidateGeneratePatches(
-		t,
-		generatorFunc,
-		capitest.PatchTestDef{
-			Name: "unset variable",
-		},
-		capitest.PatchTestDef{
-			Name: "iamInstanceProfile set",
-			Vars: []runtimehooksv1.Variable{
-				capitest.VariableWithValue(
-					variableName,
+					workerconfig.MetaVariableName,
 					"nodes.cluster-api-provider-aws.sigs.k8s.io",
-					variablePath...,
+					v1alpha1.AWSVariableName,
+					VariableName,
 				),
 				capitest.VariableWithValue(
 					"builtin",
@@ -84,5 +49,17 @@ func TestWorkerGeneratePatches(
 				ValueMatcher: gomega.Equal("nodes.cluster-api-provider-aws.sigs.k8s.io"),
 			}},
 		},
-	)
-}
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})

--- a/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/iaminstanceprofile/inject_worker_test.go
@@ -6,7 +6,6 @@ package iaminstanceprofile
 import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 

--- a/pkg/handlers/aws/mutation/instancetype/inject_control_plane_test.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_control_plane_test.go
@@ -1,0 +1,58 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package instancetype
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+)
+
+var _ = Describe("Generate InstanceType patches for ControlPlane", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+	}
+
+	testDefs := []capitest.PatchTestDef{
+		{
+			Name: "unset variable",
+		},
+		{
+			Name: "instanceType for controlplane set",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					clusterconfig.MetaVariableName,
+					"m5.xlarge",
+					clusterconfig.MetaControlPlaneConfigName,
+					v1alpha1.AWSVariableName,
+					VariableName,
+				),
+			},
+			RequestItem: request.NewCPAWSMachineTemplateRequestItem("1234"),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
+				Operation:    "replace",
+				Path:         "/spec/template/spec/instanceType",
+				ValueMatcher: gomega.Equal("m5.xlarge"),
+			}},
+		},
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})

--- a/pkg/handlers/aws/mutation/instancetype/inject_suite_test.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package instancetype
 
 import (

--- a/pkg/handlers/aws/mutation/instancetype/inject_suite_test.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_suite_test.go
@@ -1,0 +1,13 @@
+package instancetype
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInstanceTypePatch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "InstanceType patches for ControlPlane and Workers suite")
+}

--- a/pkg/handlers/aws/mutation/instancetype/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_worker_test.go
@@ -1,74 +1,39 @@
 // Copyright 2023 D2iQ, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package tests
+package instancetype
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
 )
 
-func TestControlPlaneGeneratePatches(
-	t *testing.T,
-	generatorFunc func() mutation.GeneratePatches,
-	variableName string,
-	variablePath ...string,
-) {
-	t.Helper()
+var _ = Describe("Generate InstanceType patches for Worker", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+	}
 
-	capitest.ValidateGeneratePatches(
-		t,
-		generatorFunc,
-		capitest.PatchTestDef{
+	testDefs := []capitest.PatchTestDef{
+		{
 			Name: "unset variable",
 		},
-		capitest.PatchTestDef{
-			Name: "instanceType set",
+		{
+			Name: "instanceType for workers set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
-					"m5.xlarge",
-					variablePath...,
-				),
-			},
-			RequestItem: request.NewCPAWSMachineTemplateRequestItem("1234"),
-			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{{
-				Operation:    "replace",
-				Path:         "/spec/template/spec/instanceType",
-				ValueMatcher: gomega.Equal("m5.xlarge"),
-			}},
-		},
-	)
-}
-
-func TestWorkerGeneratePatches(
-	t *testing.T,
-	generatorFunc func() mutation.GeneratePatches,
-	variableName string,
-	variablePath ...string,
-) {
-	t.Helper()
-
-	capitest.ValidateGeneratePatches(
-		t,
-		generatorFunc,
-		capitest.PatchTestDef{
-			Name: "unset variable",
-		},
-		capitest.PatchTestDef{
-			Name: "instanceType set",
-			Vars: []runtimehooksv1.Variable{
-				capitest.VariableWithValue(
-					variableName,
+					workerconfig.MetaVariableName,
 					"m5.2xlarge",
-					variablePath...,
+					v1alpha1.AWSVariableName,
+					VariableName,
 				),
 				capitest.VariableWithValue(
 					"builtin",
@@ -84,5 +49,17 @@ func TestWorkerGeneratePatches(
 				ValueMatcher: gomega.Equal("m5.2xlarge"),
 			}},
 		},
-	)
-}
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})

--- a/pkg/handlers/aws/mutation/instancetype/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/instancetype/inject_worker_test.go
@@ -6,7 +6,6 @@ package instancetype
 import (
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 

--- a/pkg/handlers/aws/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/controlplaneloadbalancer"
 	controlplaneloadbalancertests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/controlplaneloadbalancer/tests"
 
-	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/instancetype"
-	instancetypetests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/instancetype/tests"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/network"
 	networktests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/network/tests"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
@@ -53,23 +51,6 @@ func TestGeneratePatches(t *testing.T) {
 	t.Parallel()
 
 	mgr := testEnv.Manager
-
-	instancetypetests.TestControlPlaneGeneratePatches(
-		t,
-		metaPatchGeneratorFunc(mgr),
-		clusterconfig.MetaVariableName,
-		clusterconfig.MetaControlPlaneConfigName,
-		v1alpha1.AWSVariableName,
-		instancetype.VariableName,
-	)
-
-	instancetypetests.TestWorkerGeneratePatches(
-		t,
-		workerPatchGeneratorFunc(),
-		workerconfig.MetaVariableName,
-		v1alpha1.AWSVariableName,
-		instancetype.VariableName,
-	)
 
 	calicotests.TestGeneratePatches(
 		t,

--- a/pkg/handlers/aws/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler_test.go
@@ -8,10 +8,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
-
-	calicotests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/cni/calico/tests"
 
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
 	auditpolicytests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/auditpolicy/tests"
@@ -45,14 +42,6 @@ func TestGeneratePatches(t *testing.T) {
 	t.Parallel()
 
 	mgr := testEnv.Manager
-
-	calicotests.TestGeneratePatches(
-		t,
-		metaPatchGeneratorFunc(mgr),
-		clusterconfig.MetaVariableName,
-		"addons",
-		v1alpha1.CNIVariableName,
-	)
 
 	auditpolicytests.TestGeneratePatches(
 		t,

--- a/pkg/handlers/aws/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler_test.go
@@ -10,14 +10,11 @@ import (
 
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
-	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/ami"
-	amitests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/ami/tests"
+
 	calicotests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/cni/calico/tests"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/controlplaneloadbalancer"
 	controlplaneloadbalancertests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/controlplaneloadbalancer/tests"
 
-	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/network"
-	networktests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/network/tests"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
 	auditpolicytests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/auditpolicy/tests"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/etcd"
@@ -32,7 +29,6 @@ import (
 	globalimageregistrymirrortests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/mirrors/tests"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/users"
 	userstests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/users/tests"
-	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
 )
 
 func metaPatchGeneratorFunc(mgr manager.Manager) func() mutation.GeneratePatches {
@@ -100,31 +96,6 @@ func TestGeneratePatches(t *testing.T) {
 		mgr.GetClient(),
 		clusterconfig.MetaVariableName,
 		mirrors.GlobalMirrorVariableName,
-	)
-
-	amitests.TestControlPlaneGeneratePatches(
-		t,
-		metaPatchGeneratorFunc(mgr),
-		clusterconfig.MetaVariableName,
-		clusterconfig.MetaControlPlaneConfigName,
-		v1alpha1.AWSVariableName,
-		ami.VariableName,
-	)
-
-	amitests.TestWorkerGeneratePatches(
-		t,
-		workerPatchGeneratorFunc(),
-		workerconfig.MetaVariableName,
-		v1alpha1.AWSVariableName,
-		ami.VariableName,
-	)
-
-	networktests.TestGeneratePatches(
-		t,
-		metaPatchGeneratorFunc(mgr),
-		clusterconfig.MetaVariableName,
-		v1alpha1.AWSVariableName,
-		network.VariableName,
 	)
 
 	controlplaneloadbalancertests.TestGeneratePatches(

--- a/pkg/handlers/aws/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler_test.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
-
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
 	auditpolicytests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/auditpolicy/tests"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/etcd"
@@ -29,12 +28,6 @@ import (
 func metaPatchGeneratorFunc(mgr manager.Manager) func() mutation.GeneratePatches {
 	return func() mutation.GeneratePatches {
 		return MetaPatchHandler(mgr).(mutation.GeneratePatches)
-	}
-}
-
-func workerPatchGeneratorFunc() func() mutation.GeneratePatches {
-	return func() mutation.GeneratePatches {
-		return MetaWorkerPatchHandler().(mutation.GeneratePatches)
 	}
 }
 

--- a/pkg/handlers/aws/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler_test.go
@@ -15,8 +15,7 @@ import (
 	calicotests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/cni/calico/tests"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/controlplaneloadbalancer"
 	controlplaneloadbalancertests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/controlplaneloadbalancer/tests"
-	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/iaminstanceprofile"
-	iaminstanceprofiletests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/iaminstanceprofile/tests"
+
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/instancetype"
 	instancetypetests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/instancetype/tests"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/network"
@@ -54,23 +53,6 @@ func TestGeneratePatches(t *testing.T) {
 	t.Parallel()
 
 	mgr := testEnv.Manager
-
-	iaminstanceprofiletests.TestControlPlaneGeneratePatches(
-		t,
-		metaPatchGeneratorFunc(mgr),
-		clusterconfig.MetaVariableName,
-		clusterconfig.MetaControlPlaneConfigName,
-		v1alpha1.AWSVariableName,
-		iaminstanceprofile.VariableName,
-	)
-
-	iaminstanceprofiletests.TestWorkerGeneratePatches(
-		t,
-		workerPatchGeneratorFunc(),
-		workerconfig.MetaVariableName,
-		v1alpha1.AWSVariableName,
-		iaminstanceprofile.VariableName,
-	)
 
 	instancetypetests.TestControlPlaneGeneratePatches(
 		t,

--- a/pkg/handlers/aws/mutation/metapatch_handler_test.go
+++ b/pkg/handlers/aws/mutation/metapatch_handler_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 
 	calicotests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/cni/calico/tests"
-	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/controlplaneloadbalancer"
-	controlplaneloadbalancertests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/aws/mutation/controlplaneloadbalancer/tests"
 
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
 	auditpolicytests "github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/mutation/auditpolicy/tests"
@@ -96,14 +94,6 @@ func TestGeneratePatches(t *testing.T) {
 		mgr.GetClient(),
 		clusterconfig.MetaVariableName,
 		mirrors.GlobalMirrorVariableName,
-	)
-
-	controlplaneloadbalancertests.TestGeneratePatches(
-		t,
-		metaPatchGeneratorFunc(mgr),
-		clusterconfig.MetaVariableName,
-		v1alpha1.AWSVariableName,
-		controlplaneloadbalancer.VariableName,
 	)
 
 	userstests.TestGeneratePatches(

--- a/pkg/handlers/aws/mutation/network/inject_test.go
+++ b/pkg/handlers/aws/mutation/network/inject_test.go
@@ -8,7 +8,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
-	. "github.com/onsi/gomega"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
@@ -19,7 +18,7 @@ import (
 )
 
 func TestNetworkPatch(t *testing.T) {
-	RegisterFailHandler(Fail)
+	gomega.RegisterFailHandler(Fail)
 	RunSpecs(t, "AWS Network mutator suite")
 }
 

--- a/pkg/handlers/aws/mutation/network/inject_test.go
+++ b/pkg/handlers/aws/mutation/network/inject_test.go
@@ -1,45 +1,49 @@
 // Copyright 2023 D2iQ, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package tests
+package network
 
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
 
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
 	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
 )
 
-func TestGeneratePatches(
-	t *testing.T,
-	generatorFunc func() mutation.GeneratePatches,
-	variableName string,
-	variablePath ...string,
-) {
-	t.Helper()
+func TestNetworkPatch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS Network mutator suite")
+}
 
-	capitest.ValidateGeneratePatches(
-		t,
-		generatorFunc,
-		capitest.PatchTestDef{
+var _ = Describe("Generate AWS Network patches", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewPatch()).(mutation.GeneratePatches)
+	}
+
+	testDefs := []capitest.PatchTestDef{
+		{
 			Name: "unset variable",
 		},
-		capitest.PatchTestDef{
+		{
 			Name: "VPC ID set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
+					clusterconfig.MetaVariableName,
 					v1alpha1.AWSNetwork{
 						VPC: &v1alpha1.VPC{
 							ID: "vpc-1234",
 						},
 					},
-					variablePath...,
+					v1alpha1.AWSVariableName,
+					VariableName,
 				),
 			},
 			RequestItem: request.NewAWSClusterTemplateRequestItem("1234"),
@@ -49,11 +53,11 @@ func TestGeneratePatches(
 				ValueMatcher: gomega.Equal("vpc-1234"),
 			}},
 		},
-		capitest.PatchTestDef{
+		{
 			Name: "Subnet IDs set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
+					clusterconfig.MetaVariableName,
 					v1alpha1.AWSNetwork{
 						Subnets: v1alpha1.Subnets{
 							{ID: "subnet-1"},
@@ -61,7 +65,8 @@ func TestGeneratePatches(
 							{ID: "subnet-3"},
 						},
 					},
-					variablePath...,
+					v1alpha1.AWSVariableName,
+					VariableName,
 				),
 			},
 			RequestItem: request.NewAWSClusterTemplateRequestItem("1234"),
@@ -71,11 +76,11 @@ func TestGeneratePatches(
 				ValueMatcher: gomega.HaveLen(3),
 			}},
 		},
-		capitest.PatchTestDef{
+		{
 			Name: "both VPC ID and Subnet IDs set",
 			Vars: []runtimehooksv1.Variable{
 				capitest.VariableWithValue(
-					variableName,
+					clusterconfig.MetaVariableName,
 					v1alpha1.AWSNetwork{
 						VPC: &v1alpha1.VPC{
 							ID: "vpc-1234",
@@ -86,7 +91,8 @@ func TestGeneratePatches(
 							{ID: "subnet-3"},
 						},
 					},
-					variablePath...,
+					v1alpha1.AWSVariableName,
+					VariableName,
 				),
 			},
 			RequestItem: request.NewAWSClusterTemplateRequestItem("1234"),
@@ -100,5 +106,17 @@ func TestGeneratePatches(
 				ValueMatcher: gomega.HaveLen(3),
 			}},
 		},
-	)
-}
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})

--- a/pkg/handlers/aws/mutation/securitygroups/inject_control_plane_test.go
+++ b/pkg/handlers/aws/mutation/securitygroups/inject_control_plane_test.go
@@ -1,0 +1,75 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package securitygroups
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/clusterconfig"
+)
+
+var _ = Describe("Generate SecurityGroup patches for ControlPlane", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewControlPlanePatch()).(mutation.GeneratePatches)
+	}
+
+	testDefs := []capitest.PatchTestDef{
+		{
+			Name: "unset variable",
+		},
+		{
+			Name: "SecurityGroups for controlplane set",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					clusterconfig.MetaVariableName,
+					v1alpha1.AdditionalSecurityGroup{
+						{ID: ptr.To("sg-1")},
+						{ID: ptr.To("sg-2")},
+						{ID: ptr.To("sg-3")},
+					},
+					clusterconfig.MetaControlPlaneConfigName,
+					v1alpha1.AWSVariableName,
+					VariableName,
+				),
+			},
+			RequestItem: request.NewCPAWSMachineTemplateRequestItem("1234"),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation:    "add",
+					Path:         "/spec/template/spec/additionalSecurityGroups",
+					ValueMatcher: gomega.HaveLen(3),
+				},
+				// TODO(shalinpatel): add matcher to check if all SG are set
+				// {
+				// 	Operation: "add",
+				// 	Path:      "/spec/template/spec/additionalSecurityGroups",
+				// 	ValueMatcher: gomega.ContainElements(
+				// 		gomega.HaveKeyWithValue("id", "sg-1"),
+				// 		gomega.HaveKeyWithValue("id", "sg-2"),
+				// 		gomega.HaveKeyWithValue("id", "sg-3"),
+				// 	),
+				// },
+			},
+		},
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})

--- a/pkg/handlers/aws/mutation/securitygroups/inject_suite_test.go
+++ b/pkg/handlers/aws/mutation/securitygroups/inject_suite_test.go
@@ -1,0 +1,16 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package securitygroups
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSecurityGroupsPatch(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AWS security groups patches for ControlPlane and Workers suite")
+}

--- a/pkg/handlers/aws/mutation/securitygroups/inject_worker_test.go
+++ b/pkg/handlers/aws/mutation/securitygroups/inject_worker_test.go
@@ -1,0 +1,81 @@
+// Copyright 2023 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package securitygroups
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/gomega"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/utils/ptr"
+	runtimehooksv1 "sigs.k8s.io/cluster-api/exp/runtime/hooks/api/v1alpha1"
+
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/api/v1alpha1"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/capi/clustertopology/handlers/mutation"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/common/pkg/testutils/capitest/request"
+	"github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pkg/handlers/generic/workerconfig"
+)
+
+var _ = Describe("Generate AWS SecurityGroups patches for Worker", func() {
+	patchGenerator := func() mutation.GeneratePatches {
+		return mutation.NewMetaGeneratePatchesHandler("", NewWorkerPatch()).(mutation.GeneratePatches)
+	}
+
+	testDefs := []capitest.PatchTestDef{
+		{
+			Name: "unset variable",
+		},
+		{
+			Name: "SecurityGroups for workers set",
+			Vars: []runtimehooksv1.Variable{
+				capitest.VariableWithValue(
+					workerconfig.MetaVariableName,
+					v1alpha1.AdditionalSecurityGroup{
+						{ID: ptr.To("sg-1")},
+						{ID: ptr.To("sg-2")},
+						{ID: ptr.To("sg-3")},
+					},
+					v1alpha1.AWSVariableName,
+					VariableName,
+				),
+				capitest.VariableWithValue(
+					"builtin",
+					apiextensionsv1.JSON{
+						Raw: []byte(`{"machineDeployment": {"class": "a-worker"}}`),
+					},
+				),
+			},
+			RequestItem: request.NewWorkerAWSMachineTemplateRequestItem("1234"),
+			ExpectedPatchMatchers: []capitest.JSONPatchMatcher{
+				{
+					Operation:    "add",
+					Path:         "/spec/template/spec/additionalSecurityGroups",
+					ValueMatcher: gomega.HaveLen(3),
+				},
+				// TODO(shalinpatel): add matcher to check if all SG are set
+				// {
+				// 	Operation: "add",
+				// 	Path:      "/spec/template/spec/additionalSecurityGroups",
+				// 	ValueMatcher: gomega.ContainElements(
+				// 		gomega.HaveKeyWithValue("id", "sg-1"),
+				// 		gomega.HaveKeyWithValue("id", "sg-2"),
+				// 		gomega.HaveKeyWithValue("id", "sg-3"),
+				// 	),
+				// },
+			},
+		},
+	}
+
+	// create test node for each case
+	for testIdx := range testDefs {
+		tt := testDefs[testIdx]
+		It(tt.Name, func() {
+			capitest.AssertGeneratePatches(
+				GinkgoT(),
+				patchGenerator,
+				&tt,
+			)
+		})
+	}
+})


### PR DESCRIPTION
This PR is stacked on https://github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pull/23
- Each commit refer to single AWS variable. 
- Moves unit tests for 
  - instance profile
  - instance type
  - ami
  - network
  - controlplane load balancer
  - aws cni ingress rules
  - security groups

**Note for reviewers**
I will create two more PRs
- move docker patch generator tests
- move generic patch generator tests