### PR TITLE
fix: don't modify user provider input for Nutanix insecure 

### DIFF
--- a/pkg/handlers/nutanix/mutation/prismcentralendpoint/inject.go
+++ b/pkg/handlers/nutanix/mutation/prismcentralendpoint/inject.go
@@ -120,13 +120,8 @@ func (h *nutanixPrismCentralEndpoint) Mutate(
 					Kind: credentials.NutanixTrustBundleKindString,
 					Data: string(decoded),
 				}
-			}
-
-			// Always force insecure to false if additional trust bundle is provided.
-			// This ensures that the trust bundle is actually used to validate the connection.
-			if additionalTrustBundle != "" && prismCentral.Insecure {
-				log.Info("AdditionalTrustBundle is provided, setting insecure to false")
-				prismCentral.Insecure = false
+				// TODO: Consider always setting Insecure to false when AdditionalTrustBundle is set.
+				// But do it in a webhook and not hidden in this handler.
 			}
 
 			obj.Spec.Template.Spec.PrismCentral = prismCentral

--- a/pkg/handlers/nutanix/mutation/prismcentralendpoint/inject_test.go
+++ b/pkg/handlers/nutanix/mutation/prismcentralendpoint/inject_test.go
@@ -102,8 +102,8 @@ var _ = Describe("Generate Nutanix Prism Central Endpoint patches", func() {
 							gomega.BeEquivalentTo("prism-central.nutanix.com"),
 						),
 						gomega.HaveKeyWithValue("port", gomega.BeEquivalentTo(9441)),
-						// Assert the insecure field was set to false as the additional trust bundle is set
-						gomega.HaveKeyWithValue("insecure", false),
+						// Assert the insecure field was not modified when additional trust bundle is set.
+						gomega.HaveKeyWithValue("insecure", true),
 						gomega.HaveKey("credentialRef"),
 						gomega.HaveKey("additionalTrustBundle"),
 					),


### PR DESCRIPTION
@deepakm-ntnx made a good point [here](https://github.com/d2iq-labs/cluster-api-runtime-extensions-nutanix/pull/28#discussion_r1552280230), the handlers should not change explicit user input.
No magic!