### PR TITLE
fix: use a LocalObjectReference for credentials Secret

### DIFF
--- a/api/v1alpha1/addon_types.go
+++ b/api/v1alpha1/addon_types.go
@@ -164,7 +164,7 @@ type CSIProvider struct {
 	Strategy AddonStrategy `json:"strategy"`
 
 	// +optional
-	Credentials *corev1.SecretReference `json:"credentials,omitempty"`
+	Credentials *corev1.LocalObjectReference `json:"credentials,omitempty"`
 }
 
 type StorageClassConfig struct {
@@ -255,9 +255,6 @@ func (CSIProvider) VariableSchema() clusterv1.VariableSchema {
 					Description: "The reference to any secret used by the CSI Provider.",
 					Properties: map[string]clusterv1.JSONSchemaProps{
 						"name": {
-							Type: "string",
-						},
-						"namespace": {
 							Type: "string",
 						},
 					},

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -290,7 +290,7 @@ func (in *CSIProvider) DeepCopyInto(out *CSIProvider) {
 	}
 	if in.Credentials != nil {
 		in, out := &in.Credentials, &out.Credentials
-		*out = new(v1.SecretReference)
+		*out = new(v1.LocalObjectReference)
 		**out = **in
 	}
 }

--- a/pkg/handlers/generic/lifecycle/csi/nutanix-csi/handler.go
+++ b/pkg/handlers/generic/lifecycle/csi/nutanix-csi/handler.go
@@ -87,8 +87,8 @@ func (n *NutanixCSI) Apply(
 				Kind:       "Secret",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace: provider.Credentials.Name,
-				Name:      provider.Credentials.Namespace,
+				Name:      provider.Credentials.Name,
+				Namespace: req.Cluster.Namespace,
 			},
 		}
 		err := n.client.Get(


### PR DESCRIPTION
Using a cross-namespace objectRef in the cluster API can lead to privilege escalation.
A user with RBAC to read Secrets in one namespace can create a cluster, and copy any Secret from any other namespace to their workload cluster.