### PR TITLE
ci: Always use latest go for govulncheck

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -225,12 +225,11 @@ jobs:
     strategy:
       matrix:
         module: [api, common, .]
+      fail-fast: false
     steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
       - id: govulncheck
         uses: golang/govulncheck-action@v1
         with:
           work-dir: ${{ matrix.module }}
           go-version-file: go.mod
+          check-latest: true


### PR DESCRIPTION
The action uses the cached version if available which could be
an older version, which has false positives wrt vulnerabilities.

Blocked by #42.