### PR TITLE
build: Specify CAPI provider versions from go module versions

### DIFF
--- a/hack/examples/bases/docker/cluster/kustomization.yaml.tmpl
+++ b/hack/examples/bases/docker/cluster/kustomization.yaml.tmpl
@@ -5,7 +5,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/cluster-template-development.yaml
+- https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_VERSION}/cluster-template-development.yaml
 
 sortOptions:
   order: fifo

--- a/hack/examples/bases/docker/clusterclass/kustomization.yaml.tmpl
+++ b/hack/examples/bases/docker/clusterclass/kustomization.yaml.tmpl
@@ -5,7 +5,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-- https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterclass-quick-start.yaml
+- https://github.com/kubernetes-sigs/cluster-api/releases/download/${CAPI_VERSION}/clusterclass-quick-start.yaml
 
 configurations:
   - kustomizeconfig.yaml

--- a/make/clusterctl.mk
+++ b/make/clusterctl.mk
@@ -1,8 +1,11 @@
 # Copyright 2023 D2iQ, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+export CAPI_VERSION := $(shell go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api)
+export CAPD_VERSION := $(shell go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api/test)
 export CAPA_VERSION := $(shell cd hack/third-party/capa && go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-provider-aws/v2)
 export CAPX_VERSION := $(shell cd hack/third-party/capx && go list -m -f '{{ .Version }}' github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
+export CAAPH_VERSION := $(shell cd hack/third-party/caaph && go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-addon-provider-helm)
 
 # Leave Nutanix credentials empty here and set it when creating the clusters
 .PHONY: clusterctl.init
@@ -15,8 +18,11 @@ clusterctl.init:
 	    NUTANIX_ENDPOINT="" NUTANIX_PASSWORD="" NUTANIX_USER="" \
 	    clusterctl init \
 	      --kubeconfig=$(KIND_KUBECONFIG) \
-	      --infrastructure docker,aws:${CAPA_VERSION},nutanix:${CAPX_VERSION} \
-	      --addon helm \
+	      --core cluster-api:$(CAPI_VERSION) \
+	      --bootstrap kubeadm:$(CAPI_VERSION) \
+	      --control-plane kubeadm:$(CAPI_VERSION) \
+	      --infrastructure docker:$(CAPD_VERSION),aws:$(CAPA_VERSION),nutanix:$(CAPX_VERSION) \
+	      --addon helm:$(CAAPH_VERSION) \
 	      --wait-providers
 
 .PHONY: clusterctl.delete

--- a/make/examples.mk
+++ b/make/examples.mk
@@ -3,10 +3,6 @@
 
 export KUBERNETES_VERSION := v1.27.5
 
-export CLUSTERCTL_VERSION := $(shell clusterctl version -o short 2>/dev/null)
-export CAPA_VERSION := $(shell cd hack/third-party/capa && go list -m -f '{{ .Version }}' sigs.k8s.io/cluster-api-provider-aws/v2)
-export CAPX_VERSION := $(shell cd hack/third-party/capx && go list -m -f '{{ .Version }}' github.com/nutanix-cloud-native/cluster-api-provider-nutanix)
-
 .PHONY: examples.sync
 examples.sync: ## Syncs the examples by fetching upstream examples and applying kustomize patches
 	hack/examples/sync.sh


### PR DESCRIPTION
This makes the deployment consistent as well as avoiding issues when providers
are in the middle of a release.
