### PR TITLE
ci: Switch to jetify-com/devbox-install-action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 
@@ -79,7 +79,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 
@@ -120,7 +120,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 
@@ -154,7 +154,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
         languages: ${{ matrix.language }}
 
     - name: Install devbox
-      uses: jetpack-io/devbox-install-action@v0.8.0
+      uses: jetify-com/devbox-install-action@v0.9.0
       with:
         enable-cache: true
 

--- a/.github/workflows/devbox-update.yml
+++ b/.github/workflows/devbox-update.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
GH org was renamed as part of company rebranding.
